### PR TITLE
INS-24945

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,10 +73,12 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
-	golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 // indirect
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
-	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
-	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/crypto v0.12.0 // indirect
+	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
+	golang.org/x/net v0.14.0 // indirect
+	golang.org/x/sys v0.11.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
+	golang.org/x/tools v0.12.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
 	google.golang.org/grpc v1.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -394,6 +394,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 h1:iU7T1X1J6yxDr0rda54sWGkHgOp5XJrqm79gcNlC2VM=
 golang.org/x/crypto v0.0.0-20220408190544-5352b0902921/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
+golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -403,6 +405,8 @@ golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 h1:VLliZ0d+/avPrXXH+OakdXhpJuEoBZuwh1m2j7U6Iug=
+golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -434,6 +438,8 @@ golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5o
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgkU2rGHdKlKowJSMN9h0=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
+golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -472,6 +478,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9wrfxYyCjk0KbXjhR55s=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
+golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -482,6 +490,8 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
+golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -499,6 +509,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.12.0 h1:YW6HUoUmYBpwSgyaGaZq1fHjrBjX1rlpZ54T6mu2kss=
+golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -136,10 +136,10 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 		propValue := propertyRemoteValue
 		var propertyLocalStateValue interface{}
 		log.Printf("[1longlonglonglong]  %s - %s - %s - %s", property.Name, property.PreferredName, property.Type, property.ArrayItemsType)
-		log.Printf("[1 propValue]  %s", propValue)
+		log.Printf("[1 propValue]  %s", sPrettyPrint(propValue))
 		if len(terraformConfigObject) > 0 && !property.ReadOnly {
 			propertyLocalStateValue = terraformConfigObject[property.GetTerraformCompliantPropertyName()]
-			log.Printf("[terraformConfig-longlonglonglong] %s", propertyLocalStateValue)
+			log.Printf("[terraformConfig-longlonglonglong] %s", sPrettyPrint(propertyLocalStateValue))
 			log.Printf("[terraformConfig case - local value -longlonglonglong] %s", resourceLocalData.Get(property.GetTerraformCompliantPropertyName()))
 		} else {
 			propertyLocalStateValue = resourceLocalData.Get(property.GetTerraformCompliantPropertyName())
@@ -148,7 +148,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 
 		if ignoreListOrderEnabled && property.shouldIgnoreOrder() {
 			propValue = processIgnoreOrderIfEnabled(*property, propertyLocalStateValue, propertyRemoteValue)
-			log.Printf("[ignore order -longlonglonglong] %s - %s", property.Name, property.PreferredName)
+			log.Printf("[ignore order -longlonglonglong] %s", sPrettyPrint(propValue))
 		}
 
 		value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
@@ -156,7 +156,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			return err
 		}
 		if value != nil {
-			log.Printf("setResourceDataProperty %s", value)
+			log.Printf("setResourceDataProperty %s", sPrettyPrint(value))
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -320,10 +320,6 @@ func convertObjectToLocalStateData(property *SpecSchemaDefinitionProperty, prope
 		}
 	}
 
-	//if len(objectInput) == 0 {
-	//	return objectInput, nil
-	//}
-
 	// This is the work around put in place to have support for complex objects considering terraform sdk limitation to use
 	// blocks only for TypeList and TypeSet . In this case, we need to make sure that the json (which reflects to a map)
 	// gets translated to the expected array of one item that terraform expects.

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -151,8 +151,8 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			log.Printf("[ignore order -longlonglonglong] %s", sPrettyPrint(propValue))
 		}
 
-		value, err := convertPayloadToLocalStateDataValue(property, propertyRemoteValue, propertyLocalStateValue)
-		//value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
+		//value, err := convertPayloadToLocalStateDataValue(property, propertyRemoteValue, propertyLocalStateValue)
+		value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func processIgnoreOrderIfEnabled(property SpecSchemaDefinitionProperty, inputPro
 		for _, inputItemValue := range inputValueArray {
 			for _, remoteItemValue := range remoteValueArray {
 				if property.equalItems(property.ArrayItemsType, inputItemValue, remoteItemValue) {
-					newPropertyValue = append(newPropertyValue, inputItemValue)
+					newPropertyValue = append(newPropertyValue, remoteItemValue)
 					log.Printf("[equal inputItemValue -longlonglonglong] %s", sPrettyPrint(inputItemValue))
 					log.Printf("[equal remoteItemValue -longlonglonglong] %s", sPrettyPrint(remoteItemValue))
 					break

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -185,9 +185,11 @@ func processIgnoreOrderIfEnabled(property SpecSchemaDefinitionProperty, inputPro
 		for _, inputItemValue := range inputValueArray {
 			for _, remoteItemValue := range remoteValueArray {
 				if property.equalItems(property.ArrayItemsType, inputItemValue, remoteItemValue) {
-					newPropertyValue = append(newPropertyValue, remoteItemValue)
+					var sortedRemoteItemValue = property.syncOrderWhenEqual(property.ArrayItemsType, inputItemValue, remoteItemValue)
+					newPropertyValue = append(newPropertyValue, sortedRemoteItemValue)
 					log.Printf("[equal inputItemValue -longlonglonglong] %s", sPrettyPrint(inputItemValue))
 					log.Printf("[equal remoteItemValue -longlonglonglong] %s", sPrettyPrint(remoteItemValue))
+					log.Printf("[equal sorted remoteItemValue -longlonglonglong] %s", sPrettyPrint(sortedRemoteItemValue))
 					break
 				}
 			}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -117,6 +117,7 @@ func dataSourceUpdateStateWithPayloadData(openAPIResource SpecResource, remoteDa
 // it will go ahead and compare the items in the list (input vs remote) for properties of type list and the flag 'IgnoreItemsOrder' set to true
 // The property names are converted into compliant terraform names if needed.
 func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteData map[string]interface{}, resourceLocalData *schema.ResourceData, ignoreListOrderEnabled bool) error {
+	log.Printf("[start ------------------------------ longlonglonglong]")
 	resourceSchema, err := openAPIResource.GetResourceSchema()
 	if err != nil {
 		return err
@@ -134,7 +135,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 
 		propValue := propertyRemoteValue
 		var propertyLocalStateValue interface{}
-		log.Printf("[1longlonglonglong]  %s", sPrettyPrint(property))
+		log.Printf("[1longlonglonglong]  %s - %s - %s - %s", property.Name, property.PreferredName, property.Type, property.ArrayItemsType)
 		if len(terraformConfigObject) > 0 && !property.ReadOnly {
 			propertyLocalStateValue = terraformConfigObject[property.GetTerraformCompliantPropertyName()]
 			log.Printf("[terraformConfig-longlonglonglong] %s", propertyLocalStateValue)

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -134,7 +134,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 
 		propValue := propertyRemoteValue
 		var propertyLocalStateValue interface{}
-		if len(terraformConfigObject) > 0 {
+		if len(terraformConfigObject) > 0 && !property.ReadOnly {
 			propertyLocalStateValue = terraformConfigObject[property.GetTerraformCompliantPropertyName()]
 		} else {
 			propertyLocalStateValue = resourceLocalData.Get(property.GetTerraformCompliantPropertyName())

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -186,6 +186,8 @@ func processIgnoreOrderIfEnabled(property SpecSchemaDefinitionProperty, inputPro
 			for _, remoteItemValue := range remoteValueArray {
 				if property.equalItems(property.ArrayItemsType, inputItemValue, remoteItemValue) {
 					newPropertyValue = append(newPropertyValue, inputItemValue)
+					log.Printf("[equal inputItemValue -longlonglonglong] %s", sPrettyPrint(inputItemValue))
+					log.Printf("[equal remoteItemValue -longlonglonglong] %s", sPrettyPrint(remoteItemValue))
 					break
 				}
 			}
@@ -196,18 +198,23 @@ func processIgnoreOrderIfEnabled(property SpecSchemaDefinitionProperty, inputPro
 			for _, inputItemValue := range inputValueArray {
 				if property.equalItems(property.ArrayItemsType, inputItemValue, remoteItemValue) {
 					match = true
+					log.Printf("[match true -longlonglonglong] %s", sPrettyPrint(remoteItemValue))
 					break
 				}
 			}
 			if !match {
 				modifiedItems = append(modifiedItems, remoteItemValue)
+				log.Printf("[append modified remoteItemValue -longlonglonglong] %s", sPrettyPrint(remoteItemValue))
 			}
 		}
 		for _, updatedItem := range modifiedItems {
 			newPropertyValue = append(newPropertyValue, updatedItem)
+			log.Printf("[modifiedItems -longlonglonglong]")
 		}
+		log.Printf("[return newPropertyValue -longlonglonglong] %s", sPrettyPrint(newPropertyValue))
 		return newPropertyValue
 	}
+	log.Printf("[return remoteValue -longlonglonglong]")
 	return remoteValue
 }
 

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -136,9 +136,11 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 		propValue := propertyRemoteValue
 		var propertyLocalStateValue interface{}
 		log.Printf("[1longlonglonglong]  %s - %s - %s - %s", property.Name, property.PreferredName, property.Type, property.ArrayItemsType)
+		log.Printf("[1 propValue]  %s", propValue)
 		if len(terraformConfigObject) > 0 && !property.ReadOnly {
 			propertyLocalStateValue = terraformConfigObject[property.GetTerraformCompliantPropertyName()]
 			log.Printf("[terraformConfig-longlonglonglong] %s", propertyLocalStateValue)
+			log.Printf("[terraformConfig case - local value -longlonglonglong] %s", resourceLocalData.Get(property.GetTerraformCompliantPropertyName()))
 		} else {
 			propertyLocalStateValue = resourceLocalData.Get(property.GetTerraformCompliantPropertyName())
 			log.Printf("[localdata-longlonglonglong] %s", propertyLocalStateValue)
@@ -146,6 +148,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 
 		if ignoreListOrderEnabled && property.shouldIgnoreOrder() {
 			propValue = processIgnoreOrderIfEnabled(*property, propertyLocalStateValue, propertyRemoteValue)
+			log.Printf("[ignore order -longlonglonglong] %s - %s", property.Name, property.PreferredName)
 		}
 
 		value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
@@ -153,6 +156,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			return err
 		}
 		if value != nil {
+			log.Printf("setResourceDataProperty %s", value)
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -149,13 +149,11 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			propValue = processIgnoreOrderIfEnabled(*property, propertyLocalStateValue, propertyRemoteValue)
 		}
 
-		//value, err := convertPayloadToLocalStateDataValue(property, propertyRemoteValue, propertyLocalStateValue)
 		value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
 		if err != nil {
 			return err
 		}
 		if value != nil {
-			log.Printf("setResourceDataProperty %s", sPrettyPrint(value))
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}
@@ -292,9 +290,9 @@ func convertObjectToLocalStateData(property *SpecSchemaDefinitionProperty, prope
 
 	mapValue := make(map[string]interface{})
 	if propertyValue != nil {
-		var ok bool
-		mapValue, ok = propertyValue.(map[string]interface{})
-		if !ok {
+		var castOk bool
+		mapValue, castOk = propertyValue.(map[string]interface{})
+		if !castOk {
 			return nil, fmt.Errorf("invalid value '%s' for property '%s' of type '%s'", propertyValue, property.Name, property.Type)
 		}
 	}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -134,10 +134,13 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 
 		propValue := propertyRemoteValue
 		var propertyLocalStateValue interface{}
+		log.Printf("[1longlonglonglong]  %s", sPrettyPrint(property))
 		if len(terraformConfigObject) > 0 && !property.ReadOnly {
 			propertyLocalStateValue = terraformConfigObject[property.GetTerraformCompliantPropertyName()]
+			log.Printf("[terraformConfig-longlonglonglong] %s", propertyLocalStateValue)
 		} else {
 			propertyLocalStateValue = resourceLocalData.Get(property.GetTerraformCompliantPropertyName())
+			log.Printf("[localdata-longlonglonglong] %s", propertyLocalStateValue)
 		}
 
 		if ignoreListOrderEnabled && property.shouldIgnoreOrder() {

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -151,7 +151,8 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			log.Printf("[ignore order -longlonglonglong] %s", sPrettyPrint(propValue))
 		}
 
-		value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
+		value, err := convertPayloadToLocalStateDataValue(property, propertyRemoteValue, propertyLocalStateValue)
+		//value, err := convertPayloadToLocalStateDataValue(property, propValue, propertyLocalStateValue)
 		if err != nil {
 			return err
 		}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -139,7 +139,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 
 		propValue := propertyRemoteValue
 		var propertyLocalStateValue interface{}
-		if len(terraformConfigObject) > 0 && !property.isOptional() {
+		if len(terraformConfigObject) > 0 && !property.isReadOnly() {
 			propertyLocalStateValue = terraformConfigObject[property.GetTerraformCompliantPropertyName()]
 		} else {
 			propertyLocalStateValue = resourceLocalData.Get(property.GetTerraformCompliantPropertyName())

--- a/openapi/common_test.go
+++ b/openapi/common_test.go
@@ -610,7 +610,7 @@ func TestUpdateStateWithPayloadDataAndOptions(t *testing.T) {
 			}
 			err := updateStateWithPayloadDataAndOptions(r.openAPIResource, remoteData, resourceData, true)
 			Convey("Then the err returned should match the expected one", func() {
-				So(err.Error(), ShouldEqual, "wrong_property: '': source data must be an array or slice, got string")
+				So(err.Error(), ShouldEqual, "invalid value 'someValueNotMatchingTheType' for property 'wrong_property' of type 'object'")
 			})
 		})
 	})
@@ -630,7 +630,8 @@ func TestUpdateStateWithPayloadDataAndOptions(t *testing.T) {
 			remoteData := map[string]interface{}{
 				"not_well_configured_property": []interface{}{"something"},
 			}
-			err := updateStateWithPayloadDataAndOptions(r, remoteData, nil, true)
+			_, resourceData := testCreateResourceFactory(t)
+			err := updateStateWithPayloadDataAndOptions(r, remoteData, resourceData, true)
 			Convey("Then the err returned should match the expected one", func() {
 				So(err.Error(), ShouldEqual, "property 'not_well_configured_property' is supposed to be an array objects")
 			})

--- a/openapi/openapi_spec_resource_schema_definition_property.go
+++ b/openapi/openapi_spec_resource_schema_definition_property.go
@@ -419,17 +419,16 @@ func (s *SpecSchemaDefinitionProperty) equalItems(itemsType schemaDefinitionProp
 	return item1 == item2
 }
 
-// copy of equalItems with modifications to return first item with all optional properties copied from
+// recursively rearrange elements within item2 to follow order in item1
+// this is called to sync order in 2 items that equals
 func (s *SpecSchemaDefinitionProperty) syncOrderWhenEqual(itemsType schemaDefinitionPropertyType, item1, item2 interface{}) interface{} {
-	//var ret interface{}
-	//var defaultValueForType interface{} = nil
 	switch itemsType {
 	case TypeList:
 		if !s.validateValueType(item1, reflect.Slice) || !s.validateValueType(item2, reflect.Slice) {
 			return item2
 		}
 		if item1 == nil || item2 == nil {
-			return s.isOptional()
+			return item2
 		}
 		list1 := item1.([]interface{})
 		list2 := item2.([]interface{})
@@ -446,7 +445,7 @@ func (s *SpecSchemaDefinitionProperty) syncOrderWhenEqual(itemsType schemaDefini
 			for idx := range list1 {
 				for idx2 := range retList {
 					if s.equalItems(s.ArrayItemsType, list1[idx], retList[idx2]) {
-						// swap
+						// swap element
 						var tmpEntry = retList[idx]
 						retList[idx] = retList[idx2]
 						retList[idx2] = tmpEntry
@@ -460,7 +459,7 @@ func (s *SpecSchemaDefinitionProperty) syncOrderWhenEqual(itemsType schemaDefini
 		item1, _ = terraformutils.CastTerraformSliceToMap(item1) // deal with terraform schema returning nested objects as slices
 		item2, _ = terraformutils.CastTerraformSliceToMap(item2)
 		if !s.validateValueType(item1, reflect.Map) || !s.validateValueType(item2, reflect.Map) {
-			return nil
+			return item2
 		}
 		object1 := item1.(map[string]interface{})
 		object2 := item2.(map[string]interface{})

--- a/openapi/openapi_spec_resource_schema_definition_property.go
+++ b/openapi/openapi_spec_resource_schema_definition_property.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"log"
 	"reflect"
 
 	"github.com/dikhan/terraform-provider-openapi/v3/openapi/terraformutils"
@@ -451,11 +450,9 @@ func (s *SpecSchemaDefinitionProperty) syncOrderWhenEqual(itemsType schemaDefini
 						var tmpEntry = retList[idx]
 						retList[idx] = retList[idx2]
 						retList[idx2] = tmpEntry
-						log.Printf("[syncOrder swap -longlonglonglong] ")
 					}
 				}
 			}
-			log.Printf("[syncOrder sorted list -longlonglonglong] %s", retList)
 			return retList
 		}
 		return list2
@@ -473,7 +470,6 @@ func (s *SpecSchemaDefinitionProperty) syncOrderWhenEqual(itemsType schemaDefini
 			objectPropertyValue2 := objectProperty.getPropertyValueFromMap(object2)
 			retObj[objectProperty.GetTerraformCompliantPropertyName()] = objectProperty.syncOrderWhenEqual(objectProperty.Type, objectPropertyValue1, objectPropertyValue2)
 		}
-		log.Printf("[syncOrder object -longlonglonglong] %s", retObj)
 		return retObj
 	}
 

--- a/openapi/openapi_spec_resource_schema_definition_property_test.go
+++ b/openapi/openapi_spec_resource_schema_definition_property_test.go
@@ -1727,7 +1727,7 @@ func TestEqualItems(t *testing.T) {
 		},
 		{
 			name:           "bool input value doesn't match bool remote value",
-			schemaDefProp:  SpecSchemaDefinitionProperty{Type: TypeBool},
+			schemaDefProp:  SpecSchemaDefinitionProperty{Type: TypeBool, Required: true},
 			inputItem:      true,
 			remoteItem:     false,
 			expectedOutput: false,

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -570,7 +570,7 @@ func (r resourceFactory) createPayloadFromTerraformConfig(resourceLocalData *sch
 			log.Printf("[DEBUG] [resource='%s'] property payload [propertyName: %s; propertyValue: %+v]", r.openAPIResource.GetResourceName(), propertyName, input[propertyName])
 		}
 	}
-	log.Printf("[DEBUG] [resource='%s'] createPayloadFromLocalStateData: %s", r.openAPIResource.GetResourceName(), sPrettyPrint(input))
+	log.Printf("[DEBUG] [resource='%s'] createPayloadFromTerraformConfig: %s", r.openAPIResource.GetResourceName(), sPrettyPrint(input))
 	return input
 }
 

--- a/tests/e2e/data/gray_box_test_data/update-error-no-state-change/test_response_2.json
+++ b/tests/e2e/data/gray_box_test_data/update-error-no-state-change/test_response_2.json
@@ -1,8 +1,0 @@
-{
-  "id": "someid",
-  "list_props": [
-    {
-      "string_property": "string_value1"
-    }
-  ]
-}

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/openapi.yaml
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/openapi.yaml
@@ -1,0 +1,98 @@
+swagger: "2.0"
+host: %s
+schemes:
+  - "http"
+
+paths:
+  ######################
+  #### CDN Resource ####
+  ######################
+
+  /v1/cdns:
+    x-terraform-resource-name: "cdn"
+    post:
+      summary: "Create cdn"
+      operationId: "ContentDeliveryNetworkCreateV1"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "Created CDN"
+          required: true
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetworkV1"
+      responses:
+        201:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetworkV1"
+  /v1/cdns/{cdn_id}:
+    get:
+      summary: "Get cdn by id"
+      description: ""
+      operationId: "ContentDeliveryNetworkGetV1"
+      parameters:
+        - name: "cdn_id"
+          in: "path"
+          description: "The cdn id that needs to be fetched."
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetworkV1"
+    put:
+      summary: "Update cdn"
+      operationId: "ContentDeliveryNetworkDeleteV1"
+      parameters:
+        - name: "cdn_id"
+          in: "path"
+          description: "The cdn id that needs to be fetched."
+          required: true
+          type: "string"
+        - in: "body"
+          name: "body"
+          description: "Created CDN"
+          required: true
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetworkV1"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetworkV1"
+    delete:
+      summary: "Delete cdn"
+      operationId: "ContentDeliveryNetworkDeleteV1"
+      parameters:
+        - name: "id"
+          in: "path"
+          description: "The cdn that needs to be deleted"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ContentDeliveryNetworkV1"
+definitions:
+  ContentDeliveryNetworkV1:
+    type: "object"
+    properties:
+      id:
+        type: "string"
+        readOnly: true
+      main_optional_prop:
+        type: "string"
+      list_props:
+        type: "array"
+        x-terraform-field-name: "list_prop"
+        x-terraform-ignore-order: true
+        items:
+          type: "object"
+          properties:
+            sub_optional_prop:
+              type: "string"
+            sub_readonly_prop:
+              type: "string"
+              readOnly: true

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/stage1_response.json
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/stage1_response.json
@@ -1,0 +1,10 @@
+{
+  "id": "id_value",
+  "main_optional_prop": "main_optional_value",
+  "list_props": [
+    {
+      "sub_readonly_prop": "sub_readonly_value_1",
+      "sub_optional_prop": "sub_optional_value_1"
+    }
+  ]
+}

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/stage2_response.json
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/stage2_response.json
@@ -5,6 +5,10 @@
     {
       "sub_readonly_prop": "sub_readonly_value_1",
       "sub_optional_prop": "sub_optional_value_1"
+    },
+    {
+      "sub_readonly_prop": "sub_readonly_value_2",
+      "sub_optional_prop": "sub_optional_value_2"
     }
   ]
 }

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/stage2_response.json
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/stage2_response.json
@@ -1,0 +1,10 @@
+{
+  "id": "id_value",
+  "main_optional_prop": "main_optional_value_modified",
+  "list_props": [
+    {
+      "sub_readonly_prop": "sub_readonly_value_1",
+      "sub_optional_prop": "sub_optional_value_1"
+    }
+  ]
+}

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/test_stage_1.tf
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/test_stage_1.tf
@@ -1,0 +1,6 @@
+resource "openapi_cdn_v1" "my_cdn" {
+  main_optional_prop = "main_optional_value"
+  list_prop {
+    sub_optional_prop   = "sub_optional_value_1"
+  }
+}

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/test_stage_2.tf
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/test_stage_2.tf
@@ -1,6 +1,9 @@
 resource "openapi_cdn_v1" "my_cdn" {
   main_optional_prop = "main_optional_value_modified"
   list_prop {
+    sub_optional_prop   = "sub_optional_value_2"
+  }
+  list_prop {
     sub_optional_prop   = "sub_optional_value_1"
   }
 }

--- a/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/test_stage_2.tf
+++ b/tests/e2e/data/gray_box_test_data/update-state-containing-optional-properties/test_stage_2.tf
@@ -1,0 +1,6 @@
+resource "openapi_cdn_v1" "my_cdn" {
+  main_optional_prop = "main_optional_value_modified"
+  list_prop {
+    sub_optional_prop   = "sub_optional_value_1"
+  }
+}


### PR DESCRIPTION
Fix issue where tf state update results in wiping from state all properties that are not defined in tf config
such as: ID, status, etc.

regression from the fix where we use tf config as source of truth to update state, in order to have consistent order in **list** type properties.
tf config does not contain optional/read-only properties that tf state can keep