### PR TITLE
Bugfix/fix terraform refresh processing of manually deleted resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,12 +73,12 @@ require (
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
-	golang.org/x/crypto v0.12.0 // indirect
+	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
-	golang.org/x/net v0.14.0 // indirect
-	golang.org/x/sys v0.11.0 // indirect
-	golang.org/x/text v0.12.0 // indirect
-	golang.org/x/tools v0.12.0 // indirect
+	golang.org/x/net v0.15.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/tools v0.13.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
 	google.golang.org/grpc v1.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -396,6 +396,8 @@ golang.org/x/crypto v0.0.0-20220408190544-5352b0902921 h1:iU7T1X1J6yxDr0rda54sWG
 golang.org/x/crypto v0.0.0-20220408190544-5352b0902921/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.12.0 h1:tFM/ta59kqch6LlvYnPa0yx5a83cL2nHflFhYKvv9Yk=
 golang.org/x/crypto v0.12.0/go.mod h1:NF0Gs7EO5K4qLn+Ylc+fih8BSTeIjAP05siRnAh98yw=
+golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
+golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
@@ -440,6 +442,8 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgk
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
 golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
+golang.org/x/net v0.15.0 h1:ugBLEUaxABaB5AJqW9enI0ACdci2RUd4eP51NTBvuJ8=
+golang.org/x/net v0.15.0/go.mod h1:idbUs1IY1+zTqbi8yxTbhexhEEk5ur9LInksu6HrEpk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -480,6 +484,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f h1:v4INt8xihDGvnrfjMDVXGxw9w
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -492,6 +498,8 @@ golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
 golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -511,6 +519,8 @@ golang.org/x/tools v0.0.0-20200713011307-fd294ab11aed/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.12.0 h1:YW6HUoUmYBpwSgyaGaZq1fHjrBjX1rlpZ54T6mu2kss=
 golang.org/x/tools v0.12.0/go.mod h1:Sc0INKfu04TlqNoRA1hgpFZbhYXHPr4V5DzpSBTPqQM=
+golang.org/x/tools v0.13.0 h1:Iey4qkscZuv0VvIt8E0neZjtPVQFSc870HQ448QgEmQ=
+golang.org/x/tools v0.13.0/go.mod h1:HvlwmtVNQAhOuCjW7xxvovg8wbNq7LwfXh/k7wXUl58=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -104,7 +104,6 @@ func getParentIDs(openAPIResource SpecResource, data *schema.ResourceData) ([]st
 // same order as the input (if the list property has the IgnoreItemsOrder set to true). The property names are converted into compliant terraform names if needed.
 // The property names are converted into compliant terraform names if needed.
 func updateStateWithPayloadData(openAPIResource SpecResource, remoteData map[string]interface{}, resourceLocalData *schema.ResourceData) error {
-	log.Printf("[updateStateWithPayloadData - longlonglonglong] remote %s  local %s", sPrettyPrint(remoteData), resourceLocalData)
 	return updateStateWithPayloadDataAndOptions(openAPIResource, remoteData, resourceLocalData, true)
 }
 
@@ -118,7 +117,6 @@ func dataSourceUpdateStateWithPayloadData(openAPIResource SpecResource, remoteDa
 // it will go ahead and compare the items in the list (input vs remote) for properties of type list and the flag 'IgnoreItemsOrder' set to true
 // The property names are converted into compliant terraform names if needed.
 func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteData map[string]interface{}, resourceLocalData *schema.ResourceData, ignoreListOrderEnabled bool) error {
-	log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] ")
 	resourceSchema, err := openAPIResource.GetResourceSchema()
 	if err != nil {
 		return err
@@ -156,13 +154,12 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			return err
 		}
 		if value != nil {
-			log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] property %s - value %s - resourceLocalData %s", property.Name, sPrettyPrint(value), resourceLocalData.State())
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}
 		}
 	}
-	log.Printf("[updateStateWithPayloadDataAndOptions final updated- longlonglonglong] resourceLocalData %s  ---- raw %s", resourceLocalData.State(), resourceLocalData)
+
 	return nil
 }
 

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -104,7 +104,7 @@ func getParentIDs(openAPIResource SpecResource, data *schema.ResourceData) ([]st
 // same order as the input (if the list property has the IgnoreItemsOrder set to true). The property names are converted into compliant terraform names if needed.
 // The property names are converted into compliant terraform names if needed.
 func updateStateWithPayloadData(openAPIResource SpecResource, remoteData map[string]interface{}, resourceLocalData *schema.ResourceData) error {
-	log.Printf("[updateStateWithPayloadData - longlonglonglong] remote %s  local %s", sPrettyPrint(remoteData), sPrettyPrint(resourceLocalData))
+	log.Printf("[updateStateWithPayloadData - longlonglonglong] remote %s  local %s", sPrettyPrint(remoteData), resourceLocalData)
 	return updateStateWithPayloadDataAndOptions(openAPIResource, remoteData, resourceLocalData, true)
 }
 
@@ -156,7 +156,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			return err
 		}
 		if value != nil {
-			log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] value %s  resourceLocalData %s", sPrettyPrint(value), sPrettyPrint(resourceLocalData))
+			log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] value %s  resourceLocalData %s", sPrettyPrint(value), resourceLocalData)
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -156,12 +156,13 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			return err
 		}
 		if value != nil {
-			log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] value %s  resourceLocalData %s", sPrettyPrint(value), resourceLocalData)
+			log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] property %s - value %s - resourceLocalData %s", property.Name, sPrettyPrint(value), resourceLocalData.State())
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}
 		}
 	}
+	log.Printf("[updateStateWithPayloadDataAndOptions final updated- longlonglonglong] resourceLocalData %s  ---- raw %s", resourceLocalData.State(), resourceLocalData)
 	return nil
 }
 

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -162,6 +162,11 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			}
 		}
 	}
+	if remoteData == nil {
+		log.Printf("[updateStateWithPayloadDataAndOptions mark tain- longlonglonglong] resourceLocalData %s", resourceLocalData.State().Tainted)
+
+		resourceLocalData.State().Tainted = true
+	}
 	log.Printf("[updateStateWithPayloadDataAndOptions final updated- longlonglonglong] resourceLocalData %s  ---- raw %s", resourceLocalData.State(), resourceLocalData)
 	return nil
 }

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -104,6 +104,7 @@ func getParentIDs(openAPIResource SpecResource, data *schema.ResourceData) ([]st
 // same order as the input (if the list property has the IgnoreItemsOrder set to true). The property names are converted into compliant terraform names if needed.
 // The property names are converted into compliant terraform names if needed.
 func updateStateWithPayloadData(openAPIResource SpecResource, remoteData map[string]interface{}, resourceLocalData *schema.ResourceData) error {
+	log.Printf("[updateStateWithPayloadData - longlonglonglong] remote %s  local %s", sPrettyPrint(remoteData), sPrettyPrint(resourceLocalData))
 	return updateStateWithPayloadDataAndOptions(openAPIResource, remoteData, resourceLocalData, true)
 }
 
@@ -117,6 +118,7 @@ func dataSourceUpdateStateWithPayloadData(openAPIResource SpecResource, remoteDa
 // it will go ahead and compare the items in the list (input vs remote) for properties of type list and the flag 'IgnoreItemsOrder' set to true
 // The property names are converted into compliant terraform names if needed.
 func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteData map[string]interface{}, resourceLocalData *schema.ResourceData, ignoreListOrderEnabled bool) error {
+	log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] ")
 	resourceSchema, err := openAPIResource.GetResourceSchema()
 	if err != nil {
 		return err
@@ -154,6 +156,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			return err
 		}
 		if value != nil {
+			log.Printf("[updateStateWithPayloadDataAndOptions - longlonglonglong] value %s  resourceLocalData %s", sPrettyPrint(value), sPrettyPrint(resourceLocalData))
 			if err := setResourceDataProperty(*property, value, resourceLocalData); err != nil {
 				return err
 			}

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -162,13 +162,6 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			}
 		}
 	}
-	if len(remoteData) == 0 {
-		log.Printf("[updateStateWithPayloadDataAndOptions mark tain- longlonglonglong] resourceLocalData %s", resourceLocalData.State().Tainted)
-
-		resourceLocalData.State().Tainted = true
-		resourceLocalData.SetId("")
-		//resourceLocalData.State().Set(nil)
-	}
 	log.Printf("[updateStateWithPayloadDataAndOptions final updated- longlonglonglong] resourceLocalData %s  ---- raw %s", resourceLocalData.State(), resourceLocalData)
 	return nil
 }

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -159,7 +159,6 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -166,6 +166,8 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 		log.Printf("[updateStateWithPayloadDataAndOptions mark tain- longlonglonglong] resourceLocalData %s", resourceLocalData.State().Tainted)
 
 		resourceLocalData.State().Tainted = true
+		resourceLocalData.SetId("")
+		//resourceLocalData.State().Set(nil)
 	}
 	log.Printf("[updateStateWithPayloadDataAndOptions final updated- longlonglonglong] resourceLocalData %s  ---- raw %s", resourceLocalData.State(), resourceLocalData)
 	return nil

--- a/openapi/common.go
+++ b/openapi/common.go
@@ -162,7 +162,7 @@ func updateStateWithPayloadDataAndOptions(openAPIResource SpecResource, remoteDa
 			}
 		}
 	}
-	if remoteData == nil {
+	if len(remoteData) == 0 {
 		log.Printf("[updateStateWithPayloadDataAndOptions mark tain- longlonglonglong] resourceLocalData %s", resourceLocalData.State().Tainted)
 
 		resourceLocalData.State().Tainted = true

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -88,6 +88,8 @@ func (r resourceFactory) createTerraformResourceSchema() (map[string]*schema.Sch
 }
 
 func (r resourceFactory) create(data *schema.ResourceData, i interface{}) error {
+	log.Printf("[resource_factory create - longlonglonglong] data %s", data)
+
 	providerClient := i.(ClientOpenAPI)
 
 	if r.openAPIResource == nil {
@@ -129,6 +131,8 @@ func (r resourceFactory) create(data *schema.ResourceData, i interface{}) error 
 }
 
 func (r resourceFactory) readWithOptions(data *schema.ResourceData, i interface{}, handleNotFoundErr bool) error {
+	log.Printf("[resource_factory readWithOptions - longlonglonglong] data %s", data)
+
 	openAPIClient := i.(ClientOpenAPI)
 
 	if r.openAPIResource == nil {
@@ -201,7 +205,7 @@ func (r resourceFactory) getParentIDs(data *schema.ResourceData) ([]string, erro
 }
 
 func (r resourceFactory) update(data *schema.ResourceData, i interface{}) error {
-	log.Printf("[resource_factory update - longlonglonglong] data %s", sPrettyPrint(data))
+	log.Printf("[resource_factory update - longlonglonglong] data %s", data)
 
 	providerClient := i.(ClientOpenAPI)
 
@@ -426,6 +430,8 @@ func (r resourceFactory) resourceStateRefreshFunc(resourceLocalData *schema.Reso
 }
 
 func (r resourceFactory) checkImmutableFields(updatedResourceLocalData *schema.ResourceData, openAPIClient ClientOpenAPI, parentIDs ...string) error {
+	log.Printf("[resource_factory checkImmutableFields - longlonglonglong] data %s", updatedResourceLocalData)
+
 	remoteData, err := r.readRemote(updatedResourceLocalData.Id(), openAPIClient, parentIDs...)
 	if err != nil {
 		return err

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -201,6 +201,8 @@ func (r resourceFactory) getParentIDs(data *schema.ResourceData) ([]string, erro
 }
 
 func (r resourceFactory) update(data *schema.ResourceData, i interface{}) error {
+	log.Printf("[resource_factory update - longlonglonglong] data %s", sPrettyPrint(data))
+
 	providerClient := i.(ClientOpenAPI)
 
 	if r.openAPIResource == nil {

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -90,7 +90,7 @@ func (r resourceFactory) createTerraformResourceSchema() (map[string]*schema.Sch
 }
 
 func (r resourceFactory) create(data *schema.ResourceData, i interface{}) error {
-	log.Printf("[resource_factory create - longlonglonglong] data %s", data)
+	log.Printf("[resource_factory create start - longlonglonglong] state %s -- data %s", data.State(), data)
 
 	providerClient := i.(ClientOpenAPI)
 
@@ -128,6 +128,8 @@ func (r resourceFactory) create(data *schema.ResourceData, i interface{}) error 
 	if err != nil {
 		return fmt.Errorf("polling mechanism failed after POST %s call with response status code (%d): %s", resourcePath, res.StatusCode, err)
 	}
+
+	log.Printf("[resource_factory create end - longlonglonglong] state %s -- data %s", data.State(), data)
 
 	return updateStateWithPayloadData(r.openAPIResource, responsePayload, data)
 }

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -156,7 +156,9 @@ func (r resourceFactory) readWithOptions(data *schema.ResourceData, i interface{
 	if err != nil {
 		if openapiErr, ok := err.(openapierr.Error); ok {
 			if openapierr.NotFound == openapiErr.Code() && !handleNotFoundErr {
-				return updateStateWithPayloadData(r.openAPIResource, map[string]interface{}{}, data)
+				log.Printf("[resource_factory readWithOptions - longlonglonglong] removing id of resource")
+				data.SetId("")
+				return nil
 			}
 		}
 		return fmt.Errorf("[resource='%s'] GET %s/%s failed: %s", r.openAPIResource.GetResourceName(), resourcePath, data.Id(), err)

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -41,6 +41,8 @@ func newResourceFactory(openAPIResource SpecResource) resourceFactory {
 }
 
 func (r resourceFactory) createTerraformResource() (*schema.Resource, error) {
+	log.Printf("[resource_factory createTerraformResource - longlonglonglong]")
+
 	s, err := r.createTerraformResourceSchema()
 	if err != nil {
 		return nil, err
@@ -131,7 +133,7 @@ func (r resourceFactory) create(data *schema.ResourceData, i interface{}) error 
 }
 
 func (r resourceFactory) readWithOptions(data *schema.ResourceData, i interface{}, handleNotFoundErr bool) error {
-	log.Printf("[resource_factory readWithOptions - longlonglonglong] data %s", data)
+	log.Printf("[resource_factory readWithOptions - longlonglonglong] handleNotFoundErr %t -- data %s", handleNotFoundErr, data.State())
 
 	openAPIClient := i.(ClientOpenAPI)
 
@@ -162,7 +164,8 @@ func (r resourceFactory) readWithOptions(data *schema.ResourceData, i interface{
 }
 
 func (r resourceFactory) read(data *schema.ResourceData, i interface{}) error {
-	return r.readWithOptions(data, i, false)
+	log.Printf("[resource_factory read - longlonglonglong] ")
+	return r.readWithOptions(data, i, true)
 }
 
 func (r resourceFactory) readRemote(id string, providerClient ClientOpenAPI, parentIDs ...string) (map[string]interface{}, error) {

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -154,7 +154,7 @@ func (r resourceFactory) readWithOptions(data *schema.ResourceData, i interface{
 	if err != nil {
 		if openapiErr, ok := err.(openapierr.Error); ok {
 			if openapierr.NotFound == openapiErr.Code() && !handleNotFoundErr {
-				return nil
+				return updateStateWithPayloadData(r.openAPIResource, map[string]interface{}{}, data)
 			}
 		}
 		return fmt.Errorf("[resource='%s'] GET %s/%s failed: %s", r.openAPIResource.GetResourceName(), resourcePath, data.Id(), err)
@@ -165,7 +165,7 @@ func (r resourceFactory) readWithOptions(data *schema.ResourceData, i interface{
 
 func (r resourceFactory) read(data *schema.ResourceData, i interface{}) error {
 	log.Printf("[resource_factory read - longlonglonglong] ")
-	return r.readWithOptions(data, i, true)
+	return r.readWithOptions(data, i, false)
 }
 
 func (r resourceFactory) readRemote(id string, providerClient ClientOpenAPI, parentIDs ...string) (map[string]interface{}, error) {

--- a/openapi/resource_factory.go
+++ b/openapi/resource_factory.go
@@ -269,6 +269,8 @@ func (r resourceFactory) update(data *schema.ResourceData, i interface{}) error 
 }
 
 func (r resourceFactory) delete(data *schema.ResourceData, i interface{}) error {
+	log.Printf("[resource_factory delete start - longlonglonglong] data %s", data)
+
 	providerClient := i.(ClientOpenAPI)
 
 	if r.openAPIResource == nil {
@@ -299,11 +301,14 @@ func (r resourceFactory) delete(data *schema.ResourceData, i interface{}) error 
 		}
 		return fmt.Errorf("[resource='%s'] DELETE %s/%s failed: %s", r.openAPIResource.GetResourceName(), resourcePath, data.Id(), err)
 	}
+	log.Printf("[resource_factory delete 11111 - longlonglonglong] data %s", data)
 
 	err = r.handlePollingIfConfigured(nil, data, providerClient, operation, res.StatusCode, schema.TimeoutDelete)
 	if err != nil {
 		return fmt.Errorf("polling mechanism failed after DELETE %s call with response status code (%d): %s", resourcePath, res.StatusCode, err)
 	}
+
+	log.Printf("[resource_factory delete end - longlonglonglong] data %s", data)
 
 	return nil
 }


### PR DESCRIPTION
**Scenario**:
resources created and tracked by terraform can be manually deleted by provider API

**Expectation**:
terraform apply can detect resources deletion and restore them
**Issue**:
terraform refresh state ignores provider API response with 404 Not Found
hence unable to detect/restore deleted resources

**Fix**:
terraform refresh state to handle 404 Not Found properly

